### PR TITLE
feat: add copy button on token description

### DIFF
--- a/src/routes/balance/$id.tsx
+++ b/src/routes/balance/$id.tsx
@@ -299,12 +299,14 @@ function RouteComponent() {
                             <InfoBox
                                 title={t('description')}
                                 value={typeof token.token === 'object' && token.token.description || t('no_description')}
+                                copy={!!(typeof token.token === 'object' && token.token.description)}
                             />
                         )}
                         {token && token.tokenid === '0x00' && (
                             <InfoBox
                                 title={t('description')}
                                 value={t('this_is_the_official_minima_token')}
+                                copy
                             />
                         )}
                         <InfoBox title={t('sendable')} value={f(token.sendable)} />


### PR DESCRIPTION
## Description

Adds a **copy to clipboard** button on the token description field in the token detail page (`/balance/$id`).

### Before
The description field had no copy button — users had to manually select and copy the text.

### After
A copy icon appears on the right side of the description field (same as token ID, web validation URL, etc.). Tapping it copies the description to the clipboard.

### Details

- **Custom tokens**: the copy button only appears when the token actually has a description (not shown for `no_description` fallback)
- **Native Minima token** (`0x00`): the copy button is always shown (copies the default description text)
- Uses the existing `copy` prop on the `InfoBox` component — no new code needed, just enabling the feature

### Files Changed

- `src/routes/balance/$id.tsx` — Added `copy` prop to description `InfoBox` components